### PR TITLE
changes in syntax

### DIFF
--- a/grand/scheme.scm
+++ b/grand/scheme.scm
@@ -132,7 +132,7 @@
 	       natural?
 	       number/base
 	       digits/base
-	       let let* lambda define and-let*
+	       let let* lambda define and-let* or
 	       define-syntax let-syntax letrec-syntax
 	       match primitive-lambda
 	       is isnt ;; isn't


### PR DESCRIPTION
- Adding a variant of "or" that supports multiple values
- Making the behaviour of and-let* coherent with if in the context of multiple values